### PR TITLE
hls-to-udp: Add libltntstools smoother for handling UDP output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udp-to-hls"
-version = "1.0.6"
+version = "1.0.7"
 description = "UDP MpegTS to HLS VOD for UDP MpegTS Re-Stream"
 keywords = ["mpegts", "s3", "hls", "udp"]
 categories = ["command-line-utilities"]

--- a/README.md
+++ b/README.md
@@ -128,26 +128,27 @@ SEGMENT_DURATION_SECONDS=2 \
 
 ## Usage
 
-```bash
-udp-to-hls [OPTIONS]
-```
-### Options:
-- **General Settings:**
-  - `-e`, `--endpoint`: S3-compatible endpoint (default: `http://127.0.0.1:9000`)
-  - `-r`, `--region`: S3 region (default: `us-east-1`)
-  - `-b`, `--bucket`: S3 bucket name (default: `ltnhls`)
-- **UDP Stream Capture:**
-  - `-i`, `--udp_ip`: Multicast IP to filter (default: `227.1.1.102`)
-  - `-p`, `--udp_port`: UDP port to filter (default: `4102`)
-  - `-n`, `--interface`: Network interface for packet capture (default: `net1`)
-  - `-t`, `--timeout`: Packet capture timeout in milliseconds (default: `1000`)
-- **HLS Output:**
-  - `-o`, `--output_dir`: Local directory for HLS output (default: `ts`)
-  - `--remove_local`: Remove local `.ts` and `.m3u8` files after upload
-  - `--hls_keep_segments`: Number of segments to keep in the `.m3u8` index (0 = unlimited, default: `10`)
-  - `--diskless_mode`: Diskless mode avoids writing `.ts` segments to disk (default: `false`) requires --manual_segment arg.
+   | Option                                 | Description                                                  | Default                  |
+   |----------------------------------------|--------------------------------------------------------------|--------------------------|
+   | -e, --endpoint <endpoint>              | S3-compatible endpoint                                       | http://127.0.0.1:9000    |
+   | -r, --region <region>                  | S3 region                                                    | us-east-1                |
+   | -b, --bucket <bucket>                  | S3 bucket name                                               | hls                      |
+   | -i, --udp_ip <udp_ip>                  | UDP multicast IP to filter                                   | 227.1.1.102              |
+   | -p, --udp_port <udp_port>              | UDP port to filter                                           | 4102                     |
+   | -n, --interface <interface>            | Network interface for pcap                                   | net1                     |
+   | -t, --timeout <timeout>                | Capture timeout in milliseconds                              | 1000                     |
+   | -o, --output_dir <output_dir>          | Local dir for HLS output and Channel Name/Key                | channel01                |
+   | --remove_local                         | Remove local .ts/.m3u8 after uploading?                      |                          |
+   | --hls_keep_segments <hls_keep_segments>| Max segments kept in ${output_Dir}.m3u8                      | 3                        |
+   | --unsigned_urls                        | Generate unsigned S3 URLs instead of presigned URLs          |                          |
+   | --diskless_mode                        | Keep TS segments in memory only                              |                          |
+   | --diskless_ring_size <diskless_rs>     | Number of segments in memory buffer                          | 1                        |
+   | -v, --verbose <verbose>                | Verbose level                                                | 0                        |
+   | -h, --help                             | Print help                                                   |                          |
+   | -V, --version                          | Print version                                                |                          |
 
 ### Environment Variables:
+  - `CHANNEL_NAME`: Name of the channel (default: `channel01`) used as the subdirectory for HLS ts segments
   - `SEGMENT_DURATION_MS`: Duration of each segment in milliseconds (default: `1000`), (less than 1 second may not work well)
   - `FILE_MAX_AGE_SECONDS`: Maximum age of files in seconds to upload (default: `30`)
   - `URL_SIGNING_SECONDS`: Duration of signed URLs in seconds (default: `31104004`)
@@ -158,7 +159,7 @@ udp-to-hls [OPTIONS]
   - `PCAP_PACKET_HEADER_SIZE`: Size of mpegts packet ip/eth header (default: `42`)
   - `PACAP_BUFFER_SIZE`: Size of the pcap buffer (default: `4194304`)
   - `USE_ESTIMATED_DURATION`: Use estimated duration for manual segmentation (default: `true`)
-  - `HLS_INPUT_URL`: hls-to-udp input URL (default: `http://127.0.0.1:3001/index.m3u8`)
+  - `HLS_INPUT_URL`: hls-to-udp input URL (default: `http://127.0.0.1:3001/channel01.m3u8`)
   - `UDP_OUTPUT_IP`: hls-to-udp output IP for UDP (default: `224.0.0.200`)
   - `UDP_OUTPUT_PORT`: hls-to-udp output port for UDP (default: `10000`)
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ udp-to-hls [OPTIONS]
   - `--diskless_mode`: Diskless mode avoids writing `.ts` segments to disk (default: `false`) requires --manual_segment arg.
 
 ### Environment Variables:
-  - `SEGMENT_DURATION_SECONDS`: Duration of each segment in seconds (default: `2`)
+  - `SEGMENT_DURATION_MS`: Duration of each segment in milliseconds (default: `1000`), (less than 1 second may not work well)
   - `FILE_MAX_AGE_SECONDS`: Maximum age of files in seconds to upload (default: `30`)
   - `URL_SIGNING_SECONDS`: Duration of signed URLs in seconds (default: `31104004`)
   - `MINIO_ROOT_USER`: S3 username / access key ID (default: `minioadmin`)

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ udp-to-hls [OPTIONS]
    - **Manually segments** streams by directly processing MPEG-TS packets
 3. **Upload:** A directory watcher uploads new `.ts` segments and playlists to S3 or MinIO.
 4. **Playback:** The uploaded segments are accessible via signed or unsigned URLs, enabling HLS playback.
+5. **Relay:** The hls-to-udp relay can be used to replay the content back as a multicast stream later or in real-time.
 
 ---
 

--- a/config.env
+++ b/config.env
@@ -10,10 +10,10 @@ MINIO_BUCKET_NAME=channel01
 
 # Rust application environment variables:
 SEGMENT_DURATION_MS=2000
-FILE_MAX_AGE_SECONDS=300
+FILE_MAX_AGE_SECONDS=5
 URL_SIGNING_SECONDS=604800
 # Max diskless mode segment size in memory
-MAX_SEGMENT_SIZE_BYTES=30000000
+MAX_SEGMENT_SIZE_BYTES=25000000
 
 # Network capture settings:
 NETWORK_INTERFACE=net1

--- a/config.env
+++ b/config.env
@@ -9,7 +9,7 @@ MINIO_BUCKET_NAME=channel01
 #DEBUG=true ## Uncomment to enable debug mode for MinIO
 
 # Rust application environment variables:
-SEGMENT_DURATION_MS=1000
+SEGMENT_DURATION_MS=2000
 FILE_MAX_AGE_SECONDS=300
 URL_SIGNING_SECONDS=604800
 # Max diskless mode segment size in memory

--- a/config.env
+++ b/config.env
@@ -5,8 +5,11 @@ MINIO_BROWSER_REDIRECT_URL=http://127.0.0.1:9001
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=ThisIsSecret12345.
 MINIO_REGION_NAME=us-east-1
-MINIO_BUCKET_NAME=channel01
-#DEBUG=true ## Uncomment to enable debug mode for MinIO
+MINIO_BUCKET_NAME=hls
+#DEBUG=true
+
+# Channel id 
+CHANNEL_NAME=channel01
 
 # Rust application environment variables:
 SEGMENT_DURATION_MS=2000
@@ -21,6 +24,6 @@ SOURCE_IP=227.1.1.102
 SOURCE_PORT=4102
 
 # HLS TO UDP settings:
-HLS_INPUT_URL=http://127.0.0.1:3001/index.m3u8
+HLS_INPUT_URL=http://127.0.0.1:3001/channel01.m3u8
 UDP_OUTPUT_IP=224.0.0.200
 UDP_OUTPUT_PORT=10000

--- a/config.env
+++ b/config.env
@@ -9,7 +9,7 @@ MINIO_BUCKET_NAME=channel01
 #DEBUG=true ## Uncomment to enable debug mode for MinIO
 
 # Rust application environment variables:
-SEGMENT_DURATION_SECONDS=2
+SEGMENT_DURATION_MS=1000
 FILE_MAX_AGE_SECONDS=300
 URL_SIGNING_SECONDS=604800
 # Max diskless mode segment size in memory

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,6 +81,8 @@ services:
   ######################################
   hls-http-server:
     image: docker.io/nginx:alpine
+    logging:
+      driver: none
     container_name: hls-http-server
     ports:
       - "3001:80" # Map port 3001 on the host to port 80 in the container

--- a/hls-to-udp/Cargo.toml
+++ b/hls-to-udp/Cargo.toml
@@ -24,5 +24,5 @@ log = "0.4.25"
 m3u8-rs = "6"
 reqwest = { version = "0.11", features = ["blocking"] }
 url = "2.2"
-ibltntstools-sys = { git = "https://github.com/LTNGlobal-opensource/libltntstools" }
+libltntstools-sys = { git = "https://github.com/LTNGlobal-opensource/libltntstools" }
 libltntstools = { git = "https://github.com/LTNGlobal-opensource/libltntstools" }

--- a/hls-to-udp/Cargo.toml
+++ b/hls-to-udp/Cargo.toml
@@ -24,3 +24,5 @@ log = "0.4.25"
 m3u8-rs = "6"
 reqwest = { version = "0.11", features = ["blocking"] }
 url = "2.2"
+ibltntstools-sys = { git = "https://github.com/LTNGlobal-opensource/libltntstools" }
+libltntstools = { git = "https://github.com/LTNGlobal-opensource/libltntstools" }

--- a/hls-to-udp/Cargo.toml
+++ b/hls-to-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hls-to-udp"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 description = "HLS VOD to MPEG-TS UDP Re-cast."
 keywords = ["mpegts", "s3", "hls", "udp"]

--- a/hls-to-udp/README.md
+++ b/hls-to-udp/README.md
@@ -2,7 +2,7 @@
 
 This Rust-based client reads from an HLS M3U8 playlist and rebroadcasts it as MPEG-TS over UDP. It is designed to handle the HLS produced by https://github.com/groovybits/mpegts_to_s3.git and is intended to be used as a relay for replaying that content.
 
-Currently it is recommended to smooth the output with the LTN TS Tools Bitrate Smoother [https://github.com/LTNGlobal-opensource/ltntstools/blob/master/src/bitrate_smoother.c](https://github.com/LTNGlobal-opensource/ltntstools/blob/master/src/bitrate_smoother.c). See the build project for that here [https://github.com/LTNGlobal-opensource/ltntstools-build-environment](https://github.com/LTNGlobal-opensource/ltntstools-build-environment).
+To smooth the output we use the LTN TS Tools Bitrate Smoother [https://github.com/LTNGlobal-opensource/libltntstools/blob/master/src/bitrate_smoother.c](https://github.com/LTNGlobal-opensource/libltntstools/blob/master/src/bitrate_smoother.c). 
 
 ## Features
 
@@ -19,6 +19,38 @@ Currently it is recommended to smooth the output with the LTN TS Tools Bitrate S
 1. Build the project:
     ```sh
     cargo build --release
+    ```
+
+## Usage
+
+1. Help output:
+    ```sh
+    HLS to UDP relay using LibLTNTSTools StreamModel and Smoother
+
+    Usage: hls-to-udp [OPTIONS] --m3u8-url <m3u8_url> --udp-output <udp_output>
+
+    Options:
+    -u, --m3u8-url <m3u8_url>
+    -o, --udp-output <udp_output>
+    -p, --poll-ms <poll_ms>            [default: 100]
+    -s, --history-size <history_size>  [default: 32]
+    -v, --verbose <verbose>            [default: 0]
+    -l, --latency <latency>            [default: 100]
+    -c, --pcr-pid <pcr_pid>            [default: 0x00]
+    -h, --help                         Print help
+    -V, --version                      Print version
+    ```
+
+## Example
+
+1. Run the client with the M3U8 URL and UDP address:
+    ```sh
+    ./target/release/hls-to-udp -u <M3U8_URL> -o <UDP_ADDRESS>
+    ```
+
+    Example:
+    ```sh
+    ./target/release/hls-to-udp -u http://example.com/playlist.m3u8 -o 224.0.0.200:10000
     ```
 
 ## Container Deployment

--- a/hls-to-udp/README.md
+++ b/hls-to-udp/README.md
@@ -23,23 +23,27 @@ To smooth the output we use the LTN TS Tools Bitrate Smoother [https://github.co
 
 ## Usage
 
-1. Help output:
-    ```sh
-    HLS to UDP relay using LibLTNTSTools StreamModel and Smoother
+    | hls-to-udp [OPTIONS] --m3u8-url <m3u8_url> --udp-output <udp_output_port:udp_output_ip>
+    |
+    | Option                               | Description                                 | Default  |
+    |--------------------------------------|---------------------------------------------|----------|
+    | **-u, --m3u8-url <m3u8_url>**        | The URL of the M3U8 playlist                | (none)   |
+    | **-o, --udp-output <udp_output>**    | The destination UDP address                 | (none)   |
+    | **-p, --poll-ms <poll_ms>**          | The poll interval in milliseconds           | 100      |
+    | **-s, --history-size <history_size>**| The number of segments to retain            | 1800     |
+    | **-v, --verbose <verbose>**          | Verbose mode                                | 0        |
+    | **-l, --latency <latency>**          | Additional latency in milliseconds          | 100      |
+    | **-c, --pcr-pid <pcr_pid>**          | PID to use for PCR timestamps               | 0x00     |
+    | **-r, --rate <rate>**                | Bitrate in kbps                             | 5000     |
+    | **-k, --packet-size <packet_size>**  | TS packet size in bytes                     | 1316     |
+    | **-h, --help**                       | Print help                                  | -        |
+    | **-V, --version**                    | Print version                               | -        |
 
-    Usage: hls-to-udp [OPTIONS] --m3u8-url <m3u8_url> --udp-output <udp_output>
+## Environment Variables
 
-    Options:
-    -u, --m3u8-url <m3u8_url>
-    -o, --udp-output <udp_output>
-    -p, --poll-ms <poll_ms>            [default: 100]
-    -s, --history-size <history_size>  [default: 32]
-    -v, --verbose <verbose>            [default: 0]
-    -l, --latency <latency>            [default: 100]
-    -c, --pcr-pid <pcr_pid>            [default: 0x00]
-    -h, --help                         Print help
-    -V, --version                      Print version
-    ```
+    - `HLS_INPUT_URL`: hls-to-udp input URL (default: `http://127.0.0.1:3001/channel01.m3u8`)
+    - `UDP_OUTPUT_IP`: hls-to-udp output IP for UDP (default: `224.0.0.200`)
+    - `UDP_OUTPUT_PORT`: hls-to-udp output port for UDP (default: `10000`)
 
 ## Example
 

--- a/hls-to-udp/src/main.rs
+++ b/hls-to-udp/src/main.rs
@@ -307,7 +307,7 @@ fn get_version() -> &'static str {
 fn main() -> Result<()> {
     let matches = ClapCommand::new("hls-udp-streamer")
         .version(get_version())
-        .about("HLS to UDP streamer with PCR/duration-based timing")
+        .about("HLS to UDP relay using LibLTNTSTools StreamModel and Smoother")
         .arg(
             Arg::new("m3u8_url")
                 .short('u')

--- a/hls-to-udp/src/main.rs
+++ b/hls-to-udp/src/main.rs
@@ -8,6 +8,8 @@ use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread::{self, sleep, JoinHandle};
 use std::time::{Duration, Instant};
 use url::Url;
+use libltntstools_sys::*;
+use libltntstools::PcrSmoother;
 
 use env_logger;
 

--- a/hls-to-udp/src/main.rs
+++ b/hls-to-udp/src/main.rs
@@ -214,21 +214,8 @@ fn sender_thread(
         };
         // setup channels to communicate pcr pid and bitrate to the smoother in the rx.recv() loop for setup
         let (pcr_tx, pcr_rx) = mpsc::channel();
-        let sm_callback = move |v: Vec<u8>| {
-            // Ensure we have enough bytes for the pat_s struct
-            if v.len() < std::mem::size_of::<libltntstools_sys::pat_s>() {
-                log::error!("StreamModelCallback: not enough data for pat_s.");
-                return;
-            }
-
-            // Interpret bytes as a pat_s
-            let pat: libltntstools_sys::pat_s =
-                unsafe { std::ptr::read_unaligned(v.as_ptr() as *const libltntstools_sys::pat_s) };
-
-            log::info!(
-                "StreamModelCallback: received PAT with length {} bytes.",
-                v.len()
-            );
+        let sm_callback = move |pat: &mut libltntstools_sys::pat_s| {
+            log::info!("StreamModelCallback: received PAT.");
 
             if pat.program_count > 0 {
                 log::info!(

--- a/hls-to-udp/src/main.rs
+++ b/hls-to-udp/src/main.rs
@@ -79,21 +79,21 @@ fn receiver_thread(
                 Ok(r) => {
                     if !r.status().is_success() {
                         eprintln!("ReceiverThread: 3U8 fetch HTTP error: {}", r.status());
-                        thread::sleep(Duration::from_millis(500));
+                        thread::sleep(Duration::from_millis(100));
                         continue;
                     }
                     match r.text() {
                         Ok(txt) => txt,
                         Err(e) => {
                             eprintln!("ReceiverThread: M3U8 read error: {}", e);
-                            thread::sleep(Duration::from_millis(500));
+                            thread::sleep(Duration::from_millis(100));
                             continue;
                         }
                     }
                 }
                 Err(e) => {
                     eprintln!("ReceiverThread: M3U8 request error: {}", e);
-                    thread::sleep(Duration::from_millis(500));
+                    thread::sleep(Duration::from_millis(100));
                     continue;
                 }
             };
@@ -326,7 +326,7 @@ fn main() -> Result<()> {
             Arg::new("poll_ms")
                 .short('p')
                 .long("poll-ms")
-                .default_value("500")
+                .default_value("100")
                 .action(ArgAction::Set),
         )
         .arg(
@@ -376,7 +376,7 @@ fn main() -> Result<()> {
         .get_one::<String>("poll_ms")
         .unwrap()
         .parse::<u64>()
-        .unwrap_or(500);
+        .unwrap_or(100);
     let hist_cap = matches
         .get_one::<String>("history_size")
         .unwrap()

--- a/hls-to-udp/src/main.rs
+++ b/hls-to-udp/src/main.rs
@@ -267,7 +267,7 @@ fn sender_thread(
             );
 
             // write the segment to the model for the pcr pid detection if not given
-            if pcr_pid_arg <= 0 {
+            if pcr_pid <= 0 {
                 let _ = model.write(&seg.data);
                 if let Ok(pcr_pid_detected) = pcr_rx.try_recv() {
                     if pcr_pid != pcr_pid_detected as u16 {

--- a/hls-to-udp/src/main.rs
+++ b/hls-to-udp/src/main.rs
@@ -333,7 +333,7 @@ fn main() -> Result<()> {
             Arg::new("history_size")
                 .short('s')
                 .long("history-size")
-                .default_value("32")
+                .default_value("1800")
                 .action(ArgAction::Set),
         )
         .arg(
@@ -381,7 +381,7 @@ fn main() -> Result<()> {
         .get_one::<String>("history_size")
         .unwrap()
         .parse::<usize>()
-        .unwrap_or(32);
+        .unwrap_or(1800);
     let verbose = matches
         .get_one::<String>("verbose")
         .unwrap()

--- a/hls-to-udp/src/main.rs
+++ b/hls-to-udp/src/main.rs
@@ -3,18 +3,17 @@ use clap::{Arg, ArgAction, Command as ClapCommand};
 use m3u8_rs::{parse_playlist_res, Playlist};
 use reqwest::blocking::Client;
 use std::collections::{HashSet, VecDeque};
+use std::io::Write;
 use std::net::UdpSocket;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread::{self, sleep, JoinHandle};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use url::Url;
-use libltntstools_sys::*;
+//use libltntstools_sys::*;
 use libltntstools::PcrSmoother;
 
 use env_logger;
 
-const TS_PACKET_SIZE: usize = 188;
-const MAX_UDP_BITRATE: f64 = 30_000_000.0; // 30 Mbps max
 const UDP_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 #[derive(Debug)]
@@ -57,176 +56,6 @@ impl SegmentHistory {
 fn resolve_segment_url(base: &Url, seg_path: &str) -> Result<Url> {
     base.join(seg_path)
         .map_err(|e| anyhow!("Failed URL join: {}", e))
-}
-
-fn parse_pcr(ts_packet: &[u8]) -> Option<u64> {
-    if ts_packet.len() != TS_PACKET_SIZE || ts_packet[0] != 0x47 {
-        return None;
-    }
-    let afc = (ts_packet[3] >> 4) & 0b11;
-    if afc == 0b00 || afc == 0b01 {
-        return None;
-    }
-    let adapt_len = ts_packet[4] as usize;
-    if adapt_len == 0 || (adapt_len + 5) > ts_packet.len() {
-        return None;
-    }
-    let flags = ts_packet[5];
-    if (flags & 0x10) == 0 {
-        return None;
-    }
-    if adapt_len < 7 {
-        return None;
-    }
-    if 6 + 6 > ts_packet.len() {
-        return None;
-    }
-
-    let p = &ts_packet[6..12];
-    let pcr_base = ((p[0] as u64) << 25)
-        | ((p[1] as u64) << 17)
-        | ((p[2] as u64) << 9)
-        | ((p[3] as u64) << 1)
-        | ((p[4] as u64) >> 7);
-    let pcr_ext = (((p[4] & 0x01) as u64) << 8) | (p[5] as u64);
-
-    let total_90k = pcr_base * 300 + pcr_ext;
-    Some(total_90k)
-}
-
-struct BitrateEstimator {
-    average_bitrate: f64,
-    alpha: f64,
-}
-
-impl BitrateEstimator {
-    fn new() -> Self {
-        Self {
-            average_bitrate: 4_000_000.0,
-            alpha: 0.2,
-        }
-    }
-
-    fn update(&mut self, bytes: usize, duration: f64) {
-        if duration > 0.0 {
-            let bitrate = (bytes as f64 * 8.0) / duration;
-            self.average_bitrate = self.alpha * bitrate + (1.0 - self.alpha) * self.average_bitrate;
-        }
-    }
-
-    fn current_bitrate(&self) -> f64 {
-        self.average_bitrate.min(MAX_UDP_BITRATE)
-    }
-}
-
-fn send_segment(
-    sock: &UdpSocket,
-    segment_data: &[u8],
-    last_pcr: &mut Option<u64>,
-    segment_duration: f64,
-    current_bitrate: f64,
-) -> Result<()> {
-    let num_packets = segment_data.len() / TS_PACKET_SIZE;
-    let mut any_pcr = false;
-
-    let mut offset_check = 0;
-    while offset_check + TS_PACKET_SIZE <= segment_data.len() {
-        let packet = &segment_data[offset_check..offset_check + TS_PACKET_SIZE];
-        if parse_pcr(packet).is_some() {
-            any_pcr = true;
-            break;
-        }
-        offset_check += TS_PACKET_SIZE;
-    }
-
-    if any_pcr {
-        let mut offset = 0;
-        while offset + TS_PACKET_SIZE <= segment_data.len() {
-            let packet = &segment_data[offset..offset + TS_PACKET_SIZE];
-            offset += TS_PACKET_SIZE;
-
-            if let Some(cur) = parse_pcr(packet) {
-                if let Some(prev) = *last_pcr {
-                    if cur > prev {
-                        let diff = cur - prev;
-                        let diff_secs = diff as f64 / 90_000.0;
-                        if diff_secs > 0.0 && diff_secs < 2.0 {
-                            sleep(Duration::from_secs_f64(diff_secs));
-                        }
-                    }
-                }
-                *last_pcr = Some(cur);
-            }
-
-            loop {
-                match sock.send(packet) {
-                    Ok(_) => break,
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        sleep(UDP_RETRY_DELAY);
-                    }
-                    Err(e) => return Err(e.into()),
-                }
-            }
-        }
-    } else if segment_duration > 0.0 && num_packets > 0 {
-        let calculated_duration =
-            segment_duration.max((segment_data.len() as f64 * 8.0) / current_bitrate);
-
-        let time_per_packet = calculated_duration / num_packets as f64;
-        let start_time = Instant::now();
-        let mut offset = 0;
-
-        for i in 0..num_packets {
-            let target_time = start_time + Duration::from_secs_f64(i as f64 * time_per_packet);
-
-            let packet = &segment_data[offset..offset + TS_PACKET_SIZE];
-            loop {
-                match sock.send(packet) {
-                    Ok(_) => break,
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        sleep(UDP_RETRY_DELAY);
-                    }
-                    Err(e) => return Err(e.into()),
-                }
-            }
-
-            offset += TS_PACKET_SIZE;
-
-            let now = Instant::now();
-            if let Some(remaining) = target_time.checked_duration_since(now) {
-                sleep(remaining);
-            }
-        }
-    } else {
-        let packet_size_bits = (TS_PACKET_SIZE * 8) as f64;
-        let interval = packet_size_bits / current_bitrate;
-        let mut offset = 0;
-
-        while (offset + TS_PACKET_SIZE ) <= segment_data.len() {
-            let send_start = Instant::now();
-            let packet = &segment_data[offset..offset + TS_PACKET_SIZE];
-
-            loop {
-                match sock.send(packet) {
-                    Ok(_) => break,
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        sleep(UDP_RETRY_DELAY);
-                    }
-                    Err(e) => return Err(e.into()),
-                }
-            }
-
-            offset += TS_PACKET_SIZE;
-
-            let elapsed = send_start.elapsed();
-            let target_duration = Duration::from_secs_f64(interval);
-            if let Some(remaining) = target_duration.checked_sub(elapsed) {
-                sleep(remaining);
-            }
-        }
-    }
-
-    Ok(())
 }
 
 fn downloader_thread(
@@ -359,23 +188,38 @@ fn sender_thread(udp_addr: String, rx: Receiver<DownloadedSegment>) -> JoinHandl
             return;
         }
 
-        let mut last_pcr: Option<u64> = None;
-        let mut bitrate_estimator = BitrateEstimator::new();
+        let callback = |v: Vec<u8>| {
+            log::debug!(
+                "Callback received buffer with {} bytes, sending to UDP.",
+                v.len()
+            );
+            loop {
+                match sock.send(v.as_slice()) {
+                    Ok(_) => break,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        sleep(UDP_RETRY_DELAY);
+                    }
+                    Err(e) => {
+                        eprintln!("UDP send error: {}", e);
+                        break;
+                    }
+                }
+            }
+        };
+        let pcr_pid = 0x31;
+        let bitrate = 20000;
+        let pkt_size = 1316;
+        let latency_ms = 50;
+        let mut smoother = PcrSmoother::new(pcr_pid, bitrate, pkt_size, latency_ms, callback);
 
         while let Ok(seg) = rx.recv() {
-            println!("Sender processing segment #{}", seg.id);
-            bitrate_estimator.update(seg.data.len(), seg.duration);
-
-            if let Err(e) = send_segment(
-                &sock,
-                &seg.data,
-                &mut last_pcr,
-                seg.duration,
-                bitrate_estimator.current_bitrate(),
-            ) {
-                eprintln!("Critical send error: {}", e);
-                break;
-            }
+            log::debug!(
+                "Sender processing segment #{} of {}bytes and {}s duration",
+                seg.id,
+                seg.data.len(),
+                seg.duration
+            );
+            let _ = smoother.write(&seg.data);
         }
         println!("Sender thread exiting.");
     })
@@ -419,7 +263,7 @@ fn main() -> Result<()> {
             Arg::new("history_size")
                 .short('s')
                 .long("history-size")
-                .default_value("100")
+                .default_value("32")
                 .action(ArgAction::Set),
         )
         .get_matches();
@@ -435,7 +279,7 @@ fn main() -> Result<()> {
         .get_one::<String>("history_size")
         .unwrap()
         .parse::<usize>()
-        .unwrap_or(100);
+        .unwrap_or(32);
 
     println!("Starting streamer:");
     println!("  M3U8 URL: {}", m3u8_url);

--- a/scripts/entrypoint_udp-to-hls.sh
+++ b/scripts/entrypoint_udp-to-hls.sh
@@ -18,7 +18,7 @@ while [ : ]; do
         -p ${SOURCE_PORT} \
         -e ${MINIO_SERVER_URL} \
         -b ${MINIO_BUCKET_NAME} \
-        -o ts \
+        -o ${CHANNEL_NAME} \
         --diskless_mode $@
 
     sleep 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -531,7 +531,8 @@ struct ManualSegmenter {
 
 impl ManualSegmenter {
     fn new(output_dir: &str) -> Self {
-        let playlist_path = Path::new("").join("index.m3u8");
+        let playlist_file = format!("{}.m3u8", output_dir);
+        let playlist_path = Path::new("").join(&playlist_file);
         Self {
             output_dir: output_dir.to_string(),
             current_ts_file: None,
@@ -736,7 +737,7 @@ impl ManualSegmenter {
             let mut final_path = format!("mem://segment_{}", self.segment_index + 1);
             if let (Some(ref s3c), Some(ref buck)) = (&self.s3_client, &self.s3_bucket) {
                 let segment_path = self.current_segment_path(self.segment_index + 1);
-                let object_key = format!("{}", segment_path.to_string_lossy());
+                let object_key = format!("{}/{}", self.output_dir, segment_path.to_string_lossy());
                 info!(
                     "[DISKLESS] Attempt S3 upload of object_key={}, len={}",
                     object_key,
@@ -1027,7 +1028,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             Arg::new("output_dir")
                 .short('o')
                 .long("output_dir")
-                .default_value("ts")
+                .default_value("channel01")
                 .help("Local dir for HLS output"),
         )
         .arg(


### PR DESCRIPTION
- Use libltntstools stream model and stream smoother for discovery of PCR Pid and handling timing and packet output to UDP